### PR TITLE
Create separate folders for mounts

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -3,9 +3,16 @@ on:
   push:
     branches:
       - master
+      - develop*
+      - patch*
+  pull_request:
+    branches:
+      - master
+      - develop
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/plantit/plantit/singularity.py
+++ b/plantit/plantit/singularity.py
@@ -41,7 +41,7 @@ def compose_singularity_invocation(
 
     # add bind mount arguments
     if bind_mounts is not None and len(bind_mounts) > 0:
-        command += (' --bind ' + ','.join([format_bind_mount(work_dir, mount_point) for mount_point in bind_mounts]))
+        command += (' --bind ' + ','.join([format_bind_mount(mount_point) for mount_point in bind_mounts]))
 
     # whether to use the Singularity cache
     if no_cache: command += ' --disable-cache'

--- a/plantit/plantit/task_scripts.py
+++ b/plantit/plantit/task_scripts.py
@@ -218,6 +218,10 @@ def compose_job_commands(task: Task, options: TaskOptions) -> List[str]:
         no_cache = options['no_cache'] if 'no_cache' in options else False
         shell = options['shell'] if 'shell' in options else None
 
+        # for any bind mounts, create eponymous subdirectories of the working directory
+        for mount in bind_mounts:
+            commands.append(f"mkdir -p {mount['host_path']}")
+
         if 'input' in options:
             input_kind = options['input']['kind']
             input_dir_name = options['input']['path'].rpartition('/')[2]

--- a/plantit/plantit/tasks/models.py
+++ b/plantit/plantit/tasks/models.py
@@ -210,6 +210,9 @@ class BindMount(TypedDict):
     host_path: str
     container_path: str
 
+    def __repr__(self):
+        return f"{self.host_path}:{self.container_path}"
+
 
 class Parameter(TypedDict):
     key: str

--- a/plantit/plantit/tests/integration/test_task_scripts.py
+++ b/plantit/plantit/tests/integration/test_task_scripts.py
@@ -9,6 +9,7 @@ from plantit.users.models import Profile
 from plantit.tokens import TerrainToken
 from plantit.task_lifecycle import create_immediate_task
 from plantit.task_scripts import compose_singularity_invocation
+from plantit.tasks.models import BindMount
 
 
 class TaskLifecycleTests(TestCase):

--- a/plantit/plantit/tests/unit/test_task_utils.py
+++ b/plantit/plantit/tests/unit/test_task_utils.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -305,3 +306,18 @@ class TaskUtilsTests(TestCase):
         project, study = parse_task_miappe_info(miappe)
         self.assertEqual(project, 'test-project')
         self.assertEqual(study, 'test-study')
+
+    # def test_parse_bind_mount(self):
+    #     workdir = "/tmp"
+    #     mount_str = "/opt/dev:/opt/app"
+    #     mount = parse_bind_mount(workdir, mount_str)
+    #     actual = f"{mount['host_path']}:{mount['container_path']}"
+    #     assert mount_str == actual
+
+    #     # os.path.join() ignores any arguments preceding one with a leading slash
+    #     # but in this case we really want to join the two paths, make sure it did
+    #     mount_str_no_host_path = "/opt/app"
+    #     mount = parse_bind_mount(workdir, mount_str_no_host_path)
+    #     expected = f"{workdir}{mount_str_no_host_path}:{mount_str_no_host_path}"
+    #     actual = f"{mount['host_path']}:{mount['container_path']}"
+    #     assert expected == actual

--- a/plantit/plantit/utils/tasks.py
+++ b/plantit/plantit/utils/tasks.py
@@ -13,14 +13,8 @@ from plantit.tasks.models import Task, BindMount
 logger = logging.getLogger(__name__)
 
 
-def format_bind_mount(workdir: str, bind_mount: BindMount) -> str:
-    return bind_mount['host_path'] + ':' + bind_mount['container_path'] if bind_mount['host_path'] != '' else workdir + ':' + bind_mount[
-        'container_path']
-
-
-def parse_bind_mount(workdir: str, bind_mount: str) -> BindMount:
-    split = bind_mount.rpartition(':')
-    return BindMount(host_path=split[0], container_path=split[2]) if len(split) > 0 else BindMount(host_path=workdir, container_path=bind_mount)
+def format_bind_mount(bind_mount: BindMount) -> str:
+    return bind_mount['host_path'] + ':' + bind_mount['container_path']
 
 
 def get_task_orchestrator_log_file_name(task: Task):


### PR DESCRIPTION
As described in https://github.com/Computational-Plant-Science/plantit/issues/336, multiple mounts in the YAML can share the same folder causing issues. This pull will create separate folders if there are multiple mounts and at least one uses the `work_dir` as its "host_path"