### PR TITLE
Miscellanous fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: commit
+name: build
 on:
   push:
     branches:
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Bootstrap, build, test, & push to Docker Hub
+
+      - name: Build & test
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           CYVERSE_USERNAME: ${{ secrets.CYVERSE_USERNAME }}
           CYVERSE_PASSWORD: ${{ secrets.CYVERSE_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
           GITHUB_SECRET: ${{ secrets.GITHUB_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -40,4 +40,10 @@ jobs:
           bash scripts/bootstrap.sh -n
           docker-compose -f docker-compose.dev.yml exec -T -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN plantit coverage run --source='.' ./manage.py test
           docker-compose -f docker-compose.dev.yml exec -T -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN plantit coveralls
-          docker push computationalplantscience/plantit
+        
+      - name: Push Docker image
+        if: github.repository == 'Computational-Plant-Science/plantit'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: docker push computationalplantscience/plantit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,10 @@ on:
       - master
       - develop*
       - patch*
-  pull_request:
-    branches:
-      - master
-      - develop
+  # pull_request:
+  #   branches:
+  #     - master
+  #     - develop
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,7 +42,6 @@ jobs:
           docker-compose -f docker-compose.dev.yml exec -T -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN plantit coveralls
         
       - name: Push Docker image
-        if: github.repository == 'Computational-Plant-Science/plantit'
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
             >it</small>
 </h3>
 
-continuous phenotyping automation
-
-![commit](https://github.com/Computational-Plant-Science/plantit/workflows/commit/badge.svg)
+![build](https://github.com/Computational-Plant-Science/plantit/workflows/build/badge.svg)
 ![release](https://github.com/Computational-Plant-Science/plantit/workflows/release/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/plantit/badge/?version=latest)](https://plantit.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/Computational-Plant-Science/plantit/badge.svg?branch=master)](https://coveralls.io/github/Computational-Plant-Science/plantit?branch=master)

--- a/plantit/plantit/task_scripts.py
+++ b/plantit/plantit/task_scripts.py
@@ -313,14 +313,14 @@ def compose_push_commands(task: Task, options: TaskOptions) -> List[str]:
         if 'names' in output['include']:
             for name in output['include']['names']:
                 commands.append(f"cp {join(workdir, name)} {join(staging_dir, name)}")
-                mv_zip_dir_command = mv_zip_dir_command + f"{name} "
+                mv_zip_dir_command = mv_zip_dir_command + join(staging_dir, name) + " "
         if 'patterns' in output['include']:
             for pattern in (list(output['include']['patterns'])):
                 commands.append(f"cp *{join(workdir, pattern)}* {staging_dir}/")
-                mv_zip_dir_command = mv_zip_dir_command + join(workdir, f"*{pattern}*")
+                mv_zip_dir_command = mv_zip_dir_command + join(workdir, f"*{pattern}*") + " "
             # include all scheduler log files in zip file
             for pattern in ['out', 'err']:
-                mv_zip_dir_command = mv_zip_dir_command + join(workdir, f"*.{pattern}")
+                mv_zip_dir_command = mv_zip_dir_command + join(workdir, f"*.{pattern}") + " "
     else: raise ValueError(f"No output filenames & patterns to include")
     commands.append(mv_zip_dir_command + " || echo 'No files to move'")
 

--- a/plantit/plantit/task_scripts.py
+++ b/plantit/plantit/task_scripts.py
@@ -338,7 +338,7 @@ def compose_push_commands(task: Task, options: TaskOptions) -> List[str]:
     # zip results
     zip_name = f"{task.guid}.zip"
     zip_path = join(staging_dir, zip_name)
-    zip_command = f"zip -r {zip_path} {zip_dir}/*"
+    zip_command = f"zip -j -r {zip_path} {zip_dir}/*"
     commands.append(zip_command)
 
     # transfer contents of staging dir to CyVerse


### PR DESCRIPTION
- Use absolute paths when generating job scripts. Fixes an issue causing log files to be written outside of the task working directory under certain cluster configuration.
- Trap errors when moving output files into staging/zip directories, so that Slurm jobs run successfully to completion even when expected logs or output files are not produced.
- Use `zip -j ...` (short for `--junk-paths`) in outbound transfer job script so zipfile contains no nested dirs, only files
- Minor updates to CI and `README.md`